### PR TITLE
refactor: replace os system calls in app

### DIFF
--- a/src/generate_characters.py
+++ b/src/generate_characters.py
@@ -26,28 +26,25 @@ def generate_character_portrait(character_name, character_description, project, 
         aspect_ratio="9:16"
     )
 
-    image_path = os.path.join("output", "visual_assets", f"character_{character_name.lower().replace(' ', '_')}.png")
+    image_path = os.path.join(
+        "output", "visual_assets", f"character_{character_name.lower().replace(' ', '_')}.png"
+    )
     os.makedirs(os.path.dirname(image_path), exist_ok=True)
     images[0].save(location=image_path, include_generation_parameters=True)
     print(f"Saved character portrait to {image_path}")
     return image_path
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate character portraits from a narrative schema.")
-    parser.add_argument("schema_file", help="The path to the narrative schema JSON file.")
-    parser.add_argument("--project", help="Your Google Cloud project ID.", required=True)
-    parser.add_argument("--location", help="The Google Cloud location.", default="us-central1")
-    args = parser.parse_args()
 
+def generate_characters(schema_file, project, location):
     try:
-        with open(args.schema_file, "r") as f:
+        with open(schema_file, "r") as f:
             narrative_schema = json.load(f)
     except FileNotFoundError as e:
         print(f"Error: {e}")
         return
 
     project_settings_file = "output/project_settings.json"
-    style = "photorealistic" # default style
+    style = "photorealistic"  # default style
     if os.path.exists(project_settings_file):
         with open(project_settings_file, "r") as f:
             project_settings = json.load(f)
@@ -55,9 +52,30 @@ def main():
 
     characters = narrative_schema.get("characters", [])
     for character in characters:
-        generate_character_portrait(character.get("name"), character.get("description"), args.project, args.location, style)
+        generate_character_portrait(
+            character.get("name"),
+            character.get("description"),
+            project,
+            location,
+            style,
+        )
 
     print("\nCharacter portrait generation complete.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate character portraits from a narrative schema."
+    )
+    parser.add_argument("schema_file", help="The path to the narrative schema JSON file.")
+    parser.add_argument("--project", help="Your Google Cloud project ID.", required=True)
+    parser.add_argument(
+        "--location", help="The Google Cloud location.", default="us-central1"
+    )
+    args = parser.parse_args()
+
+    generate_characters(args.schema_file, args.project, args.location)
+
 
 if __name__ == "__main__":
     main()

--- a/src/generate_environments.py
+++ b/src/generate_environments.py
@@ -41,29 +41,37 @@ def generate_environment_plate(location_name, project, gcp_location, style_profi
         print(f"Error generating environment plate for {location_name}: {e}")
         return None
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate environment plates from a narrative schema.")
-    parser.add_argument("schema_file", help="The path to the narrative schema JSON file.")
-    utils.add_vertex_args(parser)
-    utils.add_style_args(parser)
-    args = parser.parse_args()
 
+def generate_environments(schema_file, project, gcp_location):
     try:
-        with open(args.schema_file, "r") as f:
+        with open(schema_file, "r") as f:
             narrative_schema = json.load(f)
     except FileNotFoundError as e:
         print(f"Error: {e}")
         return
 
-    style_profile = utils.resolve_style_profile(args.style_profile, args.legacy_style)
+    style_profile = utils.resolve_style_profile(None, None)
 
     locations = list(set(scene.get("setting") for scene in narrative_schema.get("scenes", [])))
     for scene_location in locations:
         if not scene_location:
             continue
-        generate_environment_plate(scene_location, args.project, args.location, style_profile)
+        generate_environment_plate(scene_location, project, gcp_location, style_profile)
 
     print("\nEnvironment plate generation complete.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate environment plates from a narrative schema."
+    )
+    parser.add_argument("schema_file", help="The path to the narrative schema JSON file.")
+    utils.add_vertex_args(parser)
+    utils.add_style_args(parser)
+    args = parser.parse_args()
+
+    generate_environments(args.schema_file, args.project, args.location)
+
 
 if __name__ == "__main__":
     main()

--- a/src/generate_scene.py
+++ b/src/generate_scene.py
@@ -1,29 +1,42 @@
 import argparse
-import re
 import os
+import sys
 
-def generate_scene(storyboard_file, scene_number, project, location):
+try:
+    from .generate_storyboard_images import generate_storyboard_images  # type: ignore
+except Exception:
+    sys.path.append(os.path.dirname(__file__))
+    from generate_storyboard_images import generate_storyboard_images  # type: ignore
+
+
+def generate_scene(
+    storyboard_file, scene_number, project, location, narrative_schema_file=None
+):
     """Generates all shots for a given scene."""
-    try:
-        with open(storyboard_file, "r") as f:
-            storyboard_content = f.read()
-    except FileNotFoundError as e:
-        print(f"Error: {e}")
-        return
+    generate_storyboard_images(
+        storyboard_file,
+        narrative_schema_file,
+        project,
+        location,
+        scene=scene_number,
+    )
 
-    shot_regex = re.compile(r"SCENE (\d+), SHOT (\d+):\n(.*?)(?=\nSCENE|\Z)", re.DOTALL)
-    shots = shot_regex.findall(storyboard_content)
-
-    for current_scene_number, shot_number, shot_description in shots:
-        if int(current_scene_number) == scene_number:
-            os.system(f"python3 src/generate_storyboard_images.py {storyboard_file} --project={project} --location={location} --scene={current_scene_number} --shot={shot_number}")
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate all shots for a given scene.")
-    parser.add_argument("storyboard_file", help="The path to the text-based storyboard file.")
-    parser.add_argument("scene_number", help="The scene number to generate.", type=int)
+    parser = argparse.ArgumentParser(
+        description="Generate all shots for a given scene."
+    )
+    parser.add_argument(
+        "storyboard_file", help="The path to the text-based storyboard file."
+    )
+    parser.add_argument(
+        "scene_number", help="The scene number to generate.", type=int
+    )
     parser.add_argument("--project", help="Your Google Cloud project ID.", required=True)
-    parser.add_argument("--location", help="The Google Cloud location.", default="us-central1")
+    parser.add_argument(
+        "--location", help="The Google Cloud location.", default="us-central1"
+    )
     args = parser.parse_args()
 
     generate_scene(args.storyboard_file, args.scene_number, args.project, args.location)
+

--- a/src/generate_storyboard_images.py
+++ b/src/generate_storyboard_images.py
@@ -12,7 +12,15 @@ except Exception:
     sys.path.append(os.path.dirname(__file__))
     import utils  # type: ignore
 
-def generate_storyboard_image(shot_description, scene_number, shot_number, project, gcp_location, style_profile, narrative_schema):
+def generate_storyboard_image(
+    shot_description,
+    scene_number,
+    shot_number,
+    project,
+    gcp_location,
+    style_profile,
+    narrative_schema=None,
+):
     """Generates a storyboard image for a shot, honoring a style_profile for visual coherence."""
     print(f"Generating image for Scene {scene_number}, Shot {shot_number}...")
     try:
@@ -22,8 +30,8 @@ def generate_storyboard_image(shot_description, scene_number, shot_number, proje
         # Resolve style prompt from config; fallback to the provided style_profile string itself.
         style_prompt = utils.resolve_style_prompt(style_profile)
 
-        characters_in_shot = utils.get_characters_in_shot(shot_description, narrative_schema)
-        scene_setting = utils.get_scene_setting(int(scene_number), narrative_schema)
+        characters_in_shot = utils.get_characters_in_shot(shot_description, narrative_schema or {})
+        scene_setting = utils.get_scene_setting(int(scene_number), narrative_schema or {})
 
         prompt = f"{shot_description}\n\n"
         if characters_in_shot:
@@ -38,59 +46,95 @@ def generate_storyboard_image(shot_description, scene_number, shot_number, proje
         images = model.generate_images(
             prompt=prompt,
             number_of_images=1,
-            aspect_ratio="16:9"
+            aspect_ratio="16:9",
         )
 
-        image_path = os.path.join("output", "visual_assets", f"scene_{scene_number}_shot_{shot_number}.png")
+        image_path = os.path.join(
+            "output", "visual_assets", f"scene_{scene_number}_shot_{shot_number}.png"
+        )
         os.makedirs(os.path.dirname(image_path), exist_ok=True)
         images[0].save(location=image_path, include_generation_parameters=True)
         print(f"Saved storyboard image to {image_path}")
         return image_path
     except Exception as e:
-        print(f"Error generating storyboard image for Scene {scene_number}, Shot {shot_number}: {e}")
+        print(
+            f"Error generating storyboard image for Scene {scene_number}, Shot {shot_number}: {e}"
+        )
         return None
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate storyboard images from a storyboard file.")
-    parser.add_argument("storyboard_file", help="The path to the text-based storyboard file.")
-    parser.add_argument("narrative_schema_file", help="The path to the narrative schema JSON file.")
-    utils.add_vertex_args(parser)
-    utils.add_scene_shot_args(parser)
-    utils.add_style_args(parser)
-    args = parser.parse_args()
 
+def generate_storyboard_images(
+    storyboard_file,
+    narrative_schema_file,
+    project,
+    gcp_location,
+    scene=None,
+    shot=None,
+    style_profile=None,
+    legacy_style=None,
+):
     try:
-        with open(args.storyboard_file, "r") as f:
+        with open(storyboard_file, "r") as f:
             storyboard_content = f.read()
     except FileNotFoundError as e:
         print(f"Error: {e}")
         return
 
-    try:
-        with open(args.narrative_schema_file, "r") as f:
-            narrative_schema = json.load(f)
-    except FileNotFoundError as e:
-        print(f"Error: {e}")
-        return
+    narrative_schema = {}
+    if narrative_schema_file:
+        try:
+            with open(narrative_schema_file, "r") as f:
+                narrative_schema = json.load(f)
+        except FileNotFoundError as e:
+            print(f"Error: {e}")
+            return
 
-    style_profile = utils.resolve_style_profile(args.style_profile, args.legacy_style)
+    style_profile = utils.resolve_style_profile(style_profile, legacy_style)
 
     shots = utils.parse_storyboard_shots(storyboard_content)
 
     for scene_number, shot_number, shot_description in shots:
-        if args.scene is not None:
-            if int(scene_number) == args.scene:
-                if args.shot is not None:
-                    if int(shot_number) == args.shot:
-                        generate_storyboard_image(shot_description.strip(), scene_number, shot_number, args.project, args.location, style_profile, narrative_schema)
-                else:
-                    generate_storyboard_image(shot_description.strip(), scene_number, shot_number, args.project, args.location, style_profile, narrative_schema)
-        else:
-            # If no scene filter, generate all
-            generate_storyboard_image(shot_description.strip(), scene_number, shot_number, args.project, args.location, style_profile, narrative_schema)
-
+        if scene is not None and int(scene_number) != scene:
+            continue
+        if shot is not None and int(shot_number) != shot:
+            continue
+        generate_storyboard_image(
+            shot_description.strip(),
+            scene_number,
+            shot_number,
+            project,
+            gcp_location,
+            style_profile,
+            narrative_schema,
+        )
 
     print("\nStoryboard image generation complete.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate storyboard images from a storyboard file."
+    )
+    parser.add_argument("storyboard_file", help="The path to the text-based storyboard file.")
+    parser.add_argument(
+        "narrative_schema_file", help="The path to the narrative schema JSON file."
+    )
+    utils.add_vertex_args(parser)
+    utils.add_scene_shot_args(parser)
+    utils.add_style_args(parser)
+    args = parser.parse_args()
+
+    generate_storyboard_images(
+        args.storyboard_file,
+        args.narrative_schema_file,
+        args.project,
+        args.location,
+        scene=args.scene,
+        shot=args.shot,
+        style_profile=args.style_profile,
+        legacy_style=args.legacy_style,
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- call generation scripts via imported functions instead of os.system
- expose module functions to generate characters, environments and storyboard images
- simplify scene generation to reuse storyboard image generation

## Testing
- `pytest`
- `python -m py_compile app.py src/generate_characters.py src/generate_environments.py src/generate_storyboard_images.py src/generate_scene.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6023982dc8329bf30219d90943189